### PR TITLE
Update correct dotenv version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Store your configuration in an env file, and keep it checked out of source contr
 Include the following dependency in your `project.clj` file:
 
 ```clojure
-:dependencies [[com.knrz/dotenv "1.0.0"]]
+:dependencies [[com.knrz/dotenv "0.1.0"]]
 ```
 
 ## Usage


### PR DESCRIPTION
Can't find version 1.0.0, version 0.1.0 seems to be only one that I can find (at least) from [clojars.org](https://clojars.org/search?q=dotenv)
